### PR TITLE
Ensure `after` blocks run in proper order

### DIFF
--- a/lets_expect_core/src/core/runtime.rs
+++ b/lets_expect_core/src/core/runtime.rs
@@ -39,8 +39,8 @@ impl Runtime {
         };
 
         let new_afters = {
-            let mut new_afters = self.afters.clone();
-            new_afters.extend(afters.to_owned());
+            let mut new_afters = afters.to_owned();
+            new_afters.extend(self.afters.clone());
             new_afters
         };
 

--- a/tests/before_and_after.rs
+++ b/tests/before_and_after.rs
@@ -18,6 +18,20 @@ mod tests {
             to change(messages.len()) { from(1), to(2) }
         }
 
+        when there_are_two_messages {
+            before {
+                messages.push("second message");
+            }
+
+            after {
+                messages.remove(1);
+            }
+
+            expect(messages.len()) { to equal(2) }
+            expect(messages.get(1).unwrap()) { to equal("second message") }
+
+        }
+
         story expect_messages_to_not_be_empty {
             expect(messages.len()) to equal(1)
 


### PR DESCRIPTION
Fixes #24