### PR TITLE
Allow `expect` and `when` to have explicit identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,32 @@ expect(vec![1, 2, 3]) {
 
 `let` and `when` statements also support `mut`.
 
+### Explicit identifiers for `expect` and `when`
+
+Because Let's Expect uses standard Rust tests under the hood it has to come up with a unique identifier for each test. To make those identifiers
+readable Let's Expect uses the expressions in `expect` and `when` to generate the name. This works well for simple expressions but can get a bit
+messy for more complex expressions. Sometimes it can also result in duplicated names. To solve those issues you can use the `as` keyword to give
+the test an explicit name:
+
+```rust
+expect(a + b + c) as sum_of_three {
+    when(a = 1, b = 1, c = 1) as everything_is_one {
+        to equal(3)
+    }
+}
+```
+
+This will create a test_named:
+```text
+expect_sum_of_three::when_everything_is_one::to_equal_three
+```
+
+instead of
+
+```text
+expect_a_plus_b_plus_c::when_a_is_one_b_is_one_c_is_one::to_equal_three
+```
+
 ### Stories
 
 Let's Expect promotes tests that only test one piece of code at a time. Up until this point all the test we've seen define a subject, run that subject and

--- a/lets_expect_core/src/core/expect.rs
+++ b/lets_expect_core/src/core/expect.rs
@@ -21,17 +21,25 @@ impl Parse for Expect {
         parenthesized!(content in input);
 
         let mut mutable = false;
-        let mut subject_identifier = String::new();
 
         if content.peek(Token![mut]) {
             content.parse::<Token![mut]>()?;
-            subject_identifier = "mut_".to_string();
             mutable = true;
         }
 
         let subject = content.parse::<Expr>()?;
-        subject_identifier.push_str(&expr_to_ident(&subject));
-        let subject_identifier = Ident::new(&subject_identifier, subject.span());
+
+        let subject_identifier = if input.peek(Token![as]) {
+            input.parse::<Token![as]>()?;
+            input.parse::<Ident>()?
+        } else {
+            let mut subject_identifier = String::new();
+            if mutable {
+                subject_identifier = "mut_".to_string();
+            }
+            subject_identifier.push_str(&expr_to_ident(&subject));
+            Ident::new(&subject_identifier, subject.span())
+        };
 
         let content;
         braced!(content in input);

--- a/lets_expect_core/src/core/when.rs
+++ b/lets_expect_core/src/core/when.rs
@@ -74,6 +74,14 @@ impl Parse for When {
             )
         };
 
+        let identifier = if input.peek(Token![as]) {
+            input.parse::<Token![as]>()?;
+            let ident = input.parse::<Ident>()?;
+            Ident::new(&format!("{}{}", WHEN_IDENT_PREFIX, ident), ident.span())
+        } else {
+            identifier
+        };
+
         let content;
         braced!(content in input);
         let context = content.parse::<Context>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -883,6 +883,38 @@
 //!
 //! `let` and `when` statements also support `mut`.
 //!
+//! ## Explicit identifiers for `expect` and `when`
+//!
+//! Because Let's Expect uses standard Rust tests under the hood it has to come up with a unique identifier for each test. To make those identifiers
+//! readable Let's Expect uses the expressions in `expect` and `when` to generate the name. This works well for simple expressions but can get a bit
+//! messy for more complex expressions. Sometimes it can also result in duplicated names. To solve those issues you can use the `as` keyword to give
+//! the test an explicit name:
+//!
+//! ```
+//! # mod tests {
+//! # use lets_expect::*;
+//! # lets_expect! { #method
+//! expect(a + b + c) as sum_of_three {
+//!     when(a = 1, b = 1, c = 1) as everything_is_one {
+//!         to equal(3)
+//!     }
+//! }
+//! # }
+//! # }
+//! # tests::expect_sum_of_three::when_everything_is_one::to_equal_three().unwrap();
+//! ```
+//!
+//! This will create a test_named:
+//! ```text
+//! expect_sum_of_three::when_everything_is_one::to_equal_three
+//! ```
+//!
+//! instead of
+//!
+//! ```text
+//! expect_a_plus_b_plus_c::when_a_is_one_b_is_one_c_is_one::to_equal_three
+//! ```
+//!
 //! ## Stories
 //!
 //! Let's Expect promotes tests that only test one piece of code at a time. Up until this point all the test we've seen define a subject, run that subject and

--- a/tests/vecs.rs
+++ b/tests/vecs.rs
@@ -7,6 +7,10 @@ mod tests {
             let empty_vec: Vec<String> = vec![];
         }
 
+        expect(vec![1, 2, 3, 4, 5]) as vec_one_to_five {
+            to have(contains(&4)) be_true
+        }
+
         expect(vec![1, 2, 3]) {
             to contain_expected_values {
                 have(len()) equal(3)

--- a/tests/when.rs
+++ b/tests/when.rs
@@ -16,7 +16,7 @@ mod tests {
                 }
             }
 
-            when(a = 3, b = 3, c = 3) {
+            when(a = 3, b = 3, c = 3) as everything_is_three {
                 to equal(9)
             }
 


### PR DESCRIPTION
Fixes #50