### PR TITLE
Handle unbounded ranges in `range_to_ident`

### DIFF
--- a/lets_expect_core/src/utils/to_ident.rs
+++ b/lets_expect_core/src/utils/to_ident.rs
@@ -184,9 +184,17 @@ fn member_to_ident(member: &Member) -> String {
 }
 
 fn range_to_ident(range: &ExprRange) -> String {
-    let from = range.from.as_ref().map(|expr| expr_to_ident(expr)).unwrap();
-    let to = range.to.as_ref().map(|expr| expr_to_ident(expr)).unwrap();
-    format!("range_from_{}_to_{}", from, to)
+    let from = range
+        .from
+        .as_ref()
+        .map(|expr| format!("_from_{}", expr_to_ident(expr)))
+        .unwrap_or_default();
+    let to = range
+        .to
+        .as_ref()
+        .map(|expr| format!("_to_{}", expr_to_ident(expr)))
+        .unwrap_or_default();
+    format!("range{}{}", from, to)
 }
 
 fn expr_assign_to_ident(assign: &ExprAssign) -> String {

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -3,7 +3,7 @@ mod tests {
     use lets_expect::lets_expect;
 
     struct Array<T> {
-        data: [T; 3],
+        data: Vec<T>,
     }
 
     lets_expect! {
@@ -20,8 +20,9 @@ mod tests {
             to have(mut iter()) any(be_less_or_equal_to(1))
         }
 
-        expect(Array { data: [1, 2, 3] }) {
+        expect(Array { data: vec![1, 2, 3] }) {
             to have(data[0]) equal(1)
+            to have(data[1..].to_vec()) equal(vec![2, 3])
         }
     }
 }


### PR DESCRIPTION
Fixes #85